### PR TITLE
docs: add docs and runnable examples

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,99 @@
+# Advanced
+
+## How a match is scored
+
+`predict` does two things per registered template:
+
+1. **Structural match** — `simplematch.match(template, query)`. This must
+   succeed (return a dict, possibly empty) for the template to be a candidate at
+   all. It is what extracts the slot values.
+2. **Similarity score** — `rapidfuzz` normalized Damerau-Levenshtein similarity
+   between the *template string* (slots and all) and the query. The closer the
+   query's surface form is to the template, the higher the score.
+
+Because the score compares against the template *including* the literal `{slot}`
+markers, long captured spans pull the score down — the literal `{query}` is
+shorter than the text that fills it. This is expected: scores are a relative
+ranking signal across competing templates, not an absolute confidence.
+
+```python
+from kw_template_matcher import TemplateMatcher
+
+matcher = TemplateMatcher()
+matcher.add_templates(["set a timer for {duration}"])
+for score, slots in matcher.predict("set a timer for five minutes"):
+    print(round(score, 3), slots)
+# 0.5 {'duration': 'five minutes'}
+```
+
+## Tuning the threshold
+
+The default `0.4` is permissive. Raise it when you want only near-literal
+phrasings to match; lower it to tolerate longer slot fills and looser wording.
+
+```python
+matcher.predict("set a timer for five minutes", threshold=0.6)  # likely []
+matcher.predict("set a timer for five minutes", threshold=0.2)  # keeps the match
+```
+
+## Slot-signature routing
+
+Templates are bucketed by their sorted slot names (`"device|query"`), and each
+bucket is matched in its own thread. Two templates that capture the *same* set of
+slot names compete directly; templates with different slot sets are matched
+independently and all surviving candidates are merged, then sorted by score.
+
+A practical consequence: register related phrasings together and let `predict`
+rank them, rather than trying to hand-order templates.
+
+## Optional groups that wrap slots
+
+`[in ({device_name}|{zone_name})]` expands to one branch with no slot and several
+branches with one slot each. The slot-free branch (`play {query}`) is kept by
+`add_templates` only because it still has the `{query}` slot; a branch with *no*
+slot at all is silently dropped at registration.
+
+```python
+from kw_template_matcher import expand_template
+
+expand_template("play {query} [in ({device_name}|{zone_name})]")
+# ['play {query}',
+#  'play {query} in {device_name}',
+#  'play {query} in {zone_name}']
+```
+
+## Generating training data with `expand_slots`
+
+`expand_slots` is the inverse of matching: give it a vocabulary per slot and it
+emits every concrete utterance. Feed those into an intent classifier or use them
+as fuzz inputs for the matcher itself.
+
+```python
+from kw_template_matcher import expand_slots
+
+utterances = expand_slots(
+    "play {genre} [music]",
+    {"genre": ["jazz", "rock", "fado"]},
+)
+# both with and without "music", for each genre
+```
+
+## Gotchas
+
+- **Whitespace in expansions.** A `[the ]` optional leaves a clean single space
+  when present and collapses when absent, but constructs like `do( the | )thing`
+  can leave the spacing baked into the alternatives — design templates so each
+  branch reads naturally.
+- **Slot-free templates vanish.** Anything without a `{slot}` is not registered.
+  Use `expand_template` directly if you want the slot-free sentences.
+- **Empty-string branch.** A fully optional template (`[(this|that) is optional]`)
+  includes `''` among its expansions; it is dropped by the matcher but appears
+  from `expand_template`.
+- **Scores are comparative.** Do not threshold on an absolute notion of
+  confidence across unrelated templates; calibrate per template family.
+
+## Where next
+
+- [api.md](api.md) — exact signatures and return shapes
+- [quickstart.md](quickstart.md) — the core idea in one page
+- [opm-plugin.md](opm-plugin.md) — wiring the matcher into OVOS intent handling

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,113 @@
+# API reference
+
+Everything importable from the top-level package:
+
+```python
+from kw_template_matcher import TemplateMatcher, expand_template, expand_slots
+```
+
+## `expand_template(template: str) -> list[str]`
+
+Expand `[optional]` and `(a|b)` syntax into the full sorted list of concrete
+sentences. `{slot}` markers are preserved verbatim. The result is sorted and
+de-duplicated.
+
+```python
+from kw_template_matcher import expand_template
+
+expand_template("sentence[s] can have (pre|suf)fixes")
+# ['sentence can have prefixes',
+#  'sentence can have suffixes',
+#  'sentences can have prefixes',
+#  'sentences can have suffixes']
+```
+
+Optionals can nest alternatives, and an entirely-optional group yields the empty
+string as one branch:
+
+```python
+expand_template("[(this|that) is optional]")
+# ['', 'that is optional', 'this is optional']
+```
+
+## `expand_slots(template: str, slots: dict[str, list[str]]) -> list[str]`
+
+Run `expand_template` first, then substitute each `{slot}` with every value from
+`slots`, producing the Cartesian product. A slot with no entry in the dict is
+left as its `{name}` literal.
+
+- **template** — the template string.
+- **slots** — `{slot_name: [value, ...]}`.
+
+Returns one string per (expansion x slot-value) combination. Order follows the
+sorted expansion order, then `itertools.product` over the slot values.
+
+```python
+from kw_template_matcher import expand_slots
+
+expand_slots("turn {device} {state}",
+             {"device": ["lamp"], "state": ["on", "off"]})
+# ['turn lamp on', 'turn lamp off']
+```
+
+## `class TemplateMatcher`
+
+Holds registered templates grouped by their slot signature and matches an
+utterance back to slot values.
+
+### `TemplateMatcher()`
+
+No arguments. Internally keeps `templates: dict[str, list[str]]`, keyed by the
+sorted, `|`-joined slot names of each expanded template.
+
+### `add_templates(templates: list[str]) -> None`
+
+Expand each template and register every expansion **that contains at least one
+slot**. Slot-free expansions are dropped — the matcher only routes utterances
+that fill named holes.
+
+```python
+from kw_template_matcher import TemplateMatcher
+
+matcher = TemplateMatcher()
+matcher.add_templates([
+    "tell me a [{joke_type}] joke",
+    "play {query} [in ({device_name}|{zone_name})]",
+])
+```
+
+### `match(query: str, threshold: float = 0.4) -> dict[str, str]`
+
+Return the slot dict of the single highest-scoring template, or `{}` if nothing
+clears the threshold.
+
+```python
+matcher.match("play jazz in kitchen")
+# {'query': 'jazz', 'device_name': 'kitchen'}
+```
+
+### `predict(query: str, threshold: float = 0.4) -> list[tuple[float, dict[str, str]]]`
+
+Return every template that both structurally matches (via `simplematch`) and
+scores at or above `threshold`, as `(score, slots)` tuples sorted by descending
+score. `match` is `predict(...)[0][1]` when non-empty.
+
+- **score** — `rapidfuzz` normalized Damerau-Levenshtein similarity between the
+  template string and the query, in `[0.0, 1.0]`. Longer literal overlap and
+  fewer edits score higher.
+- **threshold** — minimum score to keep a candidate. Default `0.4`.
+
+```python
+for score, slots in matcher.predict("play jazz in kitchen"):
+    print(round(score, 3), slots)
+# 0.65 {'query': 'jazz', 'device_name': 'kitchen'}
+```
+
+A query that fills no slot structurally returns `[]` from `predict` and `{}`
+from `match`.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and the core idea
+- [advanced.md](advanced.md) — scoring intuition, thresholds, gotchas
+- [opm-plugin.md](opm-plugin.md) — the OVOS plugin built on `TemplateMatcher`

--- a/docs/opm-plugin.md
+++ b/docs/opm-plugin.md
@@ -1,0 +1,61 @@
+# OVOS plugin
+
+`kw_template_matcher.opm.KeywordTemplateMatcher` is an OVOS `IntentTransformer`
+that runs `TemplateMatcher` as a named-entity step inside the intent pipeline. It
+adds slot values to a matched intent's `match_data` without owning intent
+selection itself.
+
+It is published under the entry-point group **`opm.transformer.intent`** as
+`ovos-keyword-template-matcher`, so an OVOS install discovers it automatically.
+
+The plugin imports `ovos-bus-client`, `ovos-plugin-manager`, and `ovos-utils`,
+which come from the host OVOS environment rather than this package's runtime
+dependencies.
+
+## What it does
+
+```python
+from kw_template_matcher.opm import KeywordTemplateMatcher
+
+transformer = KeywordTemplateMatcher()
+```
+
+On `bind(bus)` it subscribes to `padatious:register_intent`. For each registered
+intent it:
+
+1. reads `samples` (or reads them from `file_name`),
+2. expands every sample with `ovos_utils.bracket_expansion.expand_template`,
+3. keeps only expansions containing a `{slot}` — pure keyword extractors,
+4. builds a `TemplateMatcher` per `(lang, intent_name)` and feeds it those
+   samples.
+
+The matchers live in `transformer.matchers[lang][intent_name]`.
+
+## The transform step
+
+During `transform(intent)` the plugin looks up the matcher for the session
+language and the intent's `match_type`. If one exists, it runs
+`matcher.match(intent.utterance)` and merges any captured slots into
+`intent.match_data`:
+
+```python
+# inside the OVOS pipeline, conceptually:
+entities = matchers[intent.match_type].match(intent.utterance)
+if entities:
+    intent.match_data.update(entities)
+```
+
+So a Padatious intent that matched on phrasing gets its slots filled by the
+template matcher, with no extra model.
+
+## Using the core matcher directly
+
+You do not need OVOS to use the matching logic — that is plain
+`TemplateMatcher`. Reach for the plugin only when you want this behaviour wired
+into a running OVOS intent pipeline; otherwise see [quickstart.md](quickstart.md).
+
+## Where next
+
+- [quickstart.md](quickstart.md) — the standalone matcher
+- [api.md](api.md) — `TemplateMatcher` signatures
+- [advanced.md](advanced.md) — scoring and routing internals

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart
+
+`keyword-template-matcher` turns compact natural-language templates into every
+sentence they describe, and matches an utterance back to the slots it filled.
+One template like `play {query} [in ({device}|{zone})]` stands in for dozens of
+phrasings without you writing them out.
+
+## Install
+
+```bash
+pip install keyword-template-matcher
+```
+
+Two runtime dependencies pull in: [`rapidfuzz`](https://github.com/maxbachmann/RapidFuzz)
+for the similarity score and [`simplematch`](https://github.com/OpenVoiceOS/simplematch)
+for slot extraction. Both are pure leaf installs.
+
+## The one idea
+
+A template is a string with three pieces of syntax:
+
+| Syntax       | Meaning                                    |
+|--------------|--------------------------------------------|
+| `{slot}`     | a named hole to capture text into          |
+| `[optional]` | a word or phrase that may be absent         |
+| `(a\|b\|c)`  | alternatives — exactly one is chosen        |
+
+`expand_template` walks the optionals and alternatives and returns the full set
+of concrete sentences. Slots are left in place as `{name}` markers.
+
+```python
+from kw_template_matcher import expand_template
+
+for sentence in expand_template("[hello,] (call me|my name is) {name}"):
+    print(sentence)
+# call me {name}
+# hello, call me {name}
+# hello, my name is {name}
+# my name is {name}
+```
+
+## First real call
+
+`TemplateMatcher` registers templates, then matches an utterance to the slots it
+captured. `match` returns the single best slot dict; `predict` returns every
+candidate with its score.
+
+```python
+from kw_template_matcher import TemplateMatcher
+
+matcher = TemplateMatcher()
+matcher.add_templates([
+    "[hello, ](call me|my name is) {name} [and] [I am from {location}]",
+])
+
+print(matcher.match("my name is Alice and I am from The United Kingdom"))
+# {'name': 'Alice', 'location': 'The United Kingdom'}
+```
+
+Want the scores too?
+
+```python
+for score, slots in matcher.predict("my name is Alice and I am from The United Kingdom"):
+    print(round(score, 3), slots)
+# 0.592 {'name': 'Alice', 'location': 'The United Kingdom'}
+```
+
+## Filling slots with values
+
+When you have a fixed vocabulary per slot, `expand_slots` substitutes every
+combination — useful for generating training utterances.
+
+```python
+from kw_template_matcher import expand_slots
+
+template = "change [the ]brightness to {level} and color to {color}"
+slots = {"level": ["low", "high"], "color": ["red", "blue"]}
+
+for sentence in expand_slots(template, slots):
+    print(sentence)
+# change the brightness to low and color to red
+# change the brightness to low and color to blue
+# ... every level x color x optional combination
+```
+
+## Where next
+
+- [api.md](api.md) — every public function and method, real signatures and return shapes
+- [advanced.md](advanced.md) — scoring, thresholds, multi-slot routing, gotchas
+- [opm-plugin.md](opm-plugin.md) — the OVOS intent-transformer plugin for live NER

--- a/examples/01_expand_template.py
+++ b/examples/01_expand_template.py
@@ -1,0 +1,24 @@
+"""Example — expand template syntax into concrete sentences.
+
+Run::
+
+    python examples/01_expand_template.py
+"""
+from kw_template_matcher import expand_template
+
+
+def main() -> None:
+    templates = [
+        "[hello,] (call me|my name is) {name}",
+        "sentence[s] can have (pre|suf)fixes mid word too",
+        "[(this|that) is optional]",
+        "play {query} [in ({device_name}|{zone_name})]",
+    ]
+    for template in templates:
+        print("###", template)
+        for sentence in expand_template(template):
+            print("   -", repr(sentence))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_expand_slots.py
+++ b/examples/02_expand_slots.py
@@ -1,0 +1,23 @@
+"""Example — fill slots with a vocabulary to generate utterances.
+
+Run::
+
+    python examples/02_expand_slots.py
+"""
+from kw_template_matcher import expand_slots
+
+
+def main() -> None:
+    template = "toca [um pouco de ]{genero} [na {divisao}]"
+    slots = {
+        "genero": ["fado", "jazz", "rock"],
+        "divisao": ["cozinha", "sala"],
+    }
+    sentences = expand_slots(template, slots)
+    print(f"{len(sentences)} generated utterances:")
+    for sentence in sentences:
+        print("   -", sentence)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_match_slots.py
+++ b/examples/03_match_slots.py
@@ -1,0 +1,23 @@
+"""Example — register templates and extract slots from an utterance.
+
+Run::
+
+    python examples/03_match_slots.py
+"""
+from kw_template_matcher import TemplateMatcher
+
+
+def main() -> None:
+    matcher = TemplateMatcher()
+    matcher.add_templates([
+        "[ola, ](chamo-me|o meu nome e) {nome} [e sou de {local}]",
+    ])
+
+    query = "o meu nome e Alice e sou de Lisboa"
+    slots = matcher.match(query)
+    print("query :", query)
+    print("slots :", slots)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_predict_scores.py
+++ b/examples/04_predict_scores.py
@@ -1,0 +1,26 @@
+"""Example — rank candidate matches by similarity score with predict().
+
+Run::
+
+    python examples/04_predict_scores.py
+"""
+from kw_template_matcher import TemplateMatcher
+
+
+def main() -> None:
+    matcher = TemplateMatcher()
+    matcher.add_templates([
+        "acende {divisao}",
+        "acende as luzes [d]a {divisao}",
+        "liga a luz [d]a {divisao}",
+    ])
+
+    query = "acende as luzes da cozinha"
+    print("query:", query)
+    print("ranked candidates (score, slots):")
+    for score, slots in matcher.predict(query):
+        print("   ", round(score, 3), slots)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_threshold.py
+++ b/examples/05_threshold.py
@@ -1,0 +1,23 @@
+"""Example — how the threshold filters loose matches.
+
+Run::
+
+    python examples/05_threshold.py
+"""
+from kw_template_matcher import TemplateMatcher
+
+
+def main() -> None:
+    matcher = TemplateMatcher()
+    matcher.add_templates(["marca um temporizador para {duracao}"])
+
+    query = "marca um temporizador para cinco minutos"
+    print("query:", query)
+    for threshold in (0.2, 0.4, 0.6):
+        results = matcher.predict(query, threshold=threshold)
+        kept = [(round(s, 3), d) for s, d in results]
+        print(f"   threshold={threshold}: {kept or 'no match'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_generate_and_match.py
+++ b/examples/06_generate_and_match.py
@@ -1,0 +1,28 @@
+"""Example — generate utterances with expand_slots, then match each one back.
+
+Run::
+
+    python examples/06_generate_and_match.py
+"""
+from kw_template_matcher import TemplateMatcher, expand_slots
+
+
+def main() -> None:
+    template = "poe {genero} [na {divisao}]"
+
+    matcher = TemplateMatcher()
+    matcher.add_templates([template])
+
+    generated = expand_slots(template, {
+        "genero": ["fado", "morna"],
+        "divisao": ["sala", "quarto"],
+    })
+
+    print("round-trip: generate then re-extract slots")
+    for utterance in generated:
+        slots = matcher.match(utterance)
+        print(f"   {utterance!r:42} -> {slots}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a house-style `docs/` directory and runnable `examples/` for the template matcher.

## docs/
- `quickstart.md` — install, the template syntax idea, first `TemplateMatcher` call
- `api.md` — `expand_template`, `expand_slots`, and `TemplateMatcher` (`add_templates`, `match`, `predict`) with real signatures and return shapes
- `advanced.md` — scoring, thresholds, slot-signature routing, gotchas
- `opm-plugin.md` — the OVOS `IntentTransformer` plugin built on the core matcher

## examples/
Six numbered scripts, public API plus stdlib only, with inline Portuguese sample text:
- `01_expand_template.py` — optionals and alternatives expansion
- `02_expand_slots.py` — fill slots from a vocabulary
- `03_match_slots.py` — extract slots from an utterance
- `04_predict_scores.py` — rank candidates by score
- `05_threshold.py` — threshold filtering
- `06_generate_and_match.py` — generate then re-extract round trip

All six examples run to exit 0.