### PR TITLE
fix: skip malformed templates during intent registration

### DIFF
--- a/kw_template_matcher/opm.py
+++ b/kw_template_matcher/opm.py
@@ -4,7 +4,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
 from ovos_plugin_manager.templates.transformers import IntentTransformer
-from ovos_utils.bracket_expansion import expand_template
+from ovos_spec_tools.expansion import expand
 from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.list_utils import deduplicate_list, flatten_list
 from ovos_utils.log import LOG
@@ -43,8 +43,16 @@ class KeywordTemplateMatcher(IntentTransformer):
             with open(file_name) as f:
                 samples = [line.strip() for line in f.readlines()]
 
-        # expand templates
-        samples = deduplicate_list(flatten_list([expand_template(s) for s in samples]))
+        # expand templates, skipping malformed ones so a single bad line
+        # never prevents the remaining samples from being registered
+        expanded = []
+        for s in samples:
+            try:
+                expanded.append(expand(s))
+            except Exception as e:
+                LOG.warning(f"Skipping malformed template for intent "
+                            f"'{name}' ({skill_id}): {s!r} ({e})")
+        samples = deduplicate_list(flatten_list(expanded))
 
         # we only care about keyword extractors, drop the rest
         samples = [s for s in samples if "{" in s]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 rapidfuzz
 simplematch
+ovos-spec-tools>=1.4.0a1

--- a/test/test_opm.py
+++ b/test/test_opm.py
@@ -1,0 +1,80 @@
+"""Tests for the OPM intent-transformer plugin.
+
+Locale files in the wild contain malformed Padatious templates
+(translated slot names, truncated braces, adjacent slots, bracketed
+markers).  A single bad line must never abort intent registration for
+the remaining samples.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+
+from kw_template_matcher.opm import KeywordTemplateMatcher
+
+
+def make_message(samples, name="test_skill:demo.intent", skill_id="test_skill"):
+    return Message("padatious:register_intent",
+                   data={"name": name, "samples": samples,
+                         "lang": "en-US", "skill_id": skill_id})
+
+
+class TestUnpackObject(unittest.TestCase):
+    def setUp(self):
+        self.plugin = KeywordTemplateMatcher()
+
+    def unpack(self, samples):
+        lang, skill_id, name, expanded, blacklist = self.plugin._unpack_object(
+            make_message(samples))
+        return expanded
+
+    def test_valid_samples_expand(self):
+        expanded = self.unpack(["play {media}", "(start|begin) {media}"])
+        self.assertIn("play {media}", expanded)
+        self.assertIn("start {media}", expanded)
+        self.assertIn("begin {media}", expanded)
+
+    def test_uppercase_slot_name_skipped(self):
+        # translated slot names, e.g. German "{Medien}"
+        expanded = self.unpack(["spiele {Medien}", "play {media}"])
+        self.assertEqual(expanded, ["play {media}"])
+
+    def test_truncated_brace_skipped(self):
+        expanded = self.unpack(["weather in {location", "weather in {location}"])
+        self.assertEqual(expanded, ["weather in {location}"])
+
+    def test_adjacent_slots_skipped(self):
+        expanded = self.unpack(["{first}{second}", "call {contact}"])
+        self.assertEqual(expanded, ["call {contact}"])
+
+    def test_bracketed_marker_does_not_raise(self):
+        # "[UNUSED]" style markers must not abort registration
+        expanded = self.unpack(["[UNUSED] play {media}"])
+        self.assertIn("play {media}", expanded)
+
+    def test_all_malformed_yields_empty(self):
+        expanded = self.unpack(["{Medien}", "{a}{b}", "{oops"])
+        self.assertEqual(expanded, [])
+
+
+class TestHandleRegisterIntent(unittest.TestCase):
+    def setUp(self):
+        self.plugin = KeywordTemplateMatcher()
+
+    def test_mixed_samples_register_valid_ones(self):
+        self.plugin.handle_register_intent(make_message(
+            ["play {Medien}", "tune to {station", "{a}{b}",
+             "[UNUSED] noise", "play {media}", "listen to {media}"]))
+        matchers = self.plugin.matchers["en-US"]
+        self.assertIn("test_skill:demo.intent", matchers)
+        result = matchers["test_skill:demo.intent"].match("play the beatles")
+        self.assertEqual(result.get("media"), "the beatles")
+
+    def test_malformed_only_does_not_raise_or_register(self):
+        self.plugin.handle_register_intent(make_message(
+            ["{Medien}", "{loc", "{a}{b}"]))
+        self.assertNotIn("test_skill:demo.intent",
+                         self.plugin.matchers.get("en-US", {}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One malformed sample in a Padatious intent file (e.g. a translated slot name like `{Medien}`, a truncated `{location`, or adjacent slots `{a}{b}`) raised `MalformedTemplate` inside `_unpack_object`, aborting registration of every sample for that intent and breaking downstream intent training.

## Changes
- Expand each sample individually; log a warning naming the bad template and skip it, keeping all valid samples.
- Replace the deprecated `ovos_utils.bracket_expansion.expand_template` import (its deprecation warning fires on every call) with `ovos_spec_tools.expansion.expand`, with `ovos-spec-tools>=1.4.0a1` declared in requirements.
- Unit tests covering invalid slot names, unbalanced braces, adjacent slots, bracketed markers, and mixed valid/malformed sample lists.

## Testing
Full test suite run locally in a fresh uv venv (Python 3.12): 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)